### PR TITLE
Fixed invalid "main" file path in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "sweetalert-react",
   "version": "0.4.4",
   "description": "Using sweetalert in React",
-  "main": "lib/SweetAlert.js",
+  "main": "src/SweetAlert.js",
   "license": "MIT",
   "repository": "chentsulin/sweetalert-react",
   "scripts": {


### PR DESCRIPTION
The `SweetAlert.js` is in `src/` directory not at `lib/`.