### PR TITLE
tweak animation prop

### DIFF
--- a/src/SweetAlert.js
+++ b/src/SweetAlert.js
@@ -97,7 +97,10 @@ export default class SweetAlert extends Component {
       }
     },
     html: PropTypes.bool,
-    animation: PropTypes.bool,
+    animation: PropTypes.oneOfType([
+      PropTypes.bool,
+      PropTypes.oneOf(['pop', 'slide-from-top', 'slide-from-bottom']),
+    ]),
     inputType: PropTypes.oneOf(ALLOWS_INPUT_TYPES),
     inputPlaceholder: PropTypes.string,
     inputValue: PropTypes.string,


### PR DESCRIPTION
allow 'pop', 'slide-from-top', 'slide-from-bottom' animation prop

Per

> animation	
>
> If set to false, the modal's animation will be disabled. Possible (string) values : pop (default when animation set to true), slide-from-top, slide-from-bottom