### PR TITLE
Explicitly compare to false for isConfirm

### DIFF
--- a/src/SweetAlert.js
+++ b/src/SweetAlert.js
@@ -228,7 +228,7 @@ export default class SweetAlert extends Component {
   }
 
   handleClick(isConfirm, onConfirm, onCancel) {
-    if (isConfirm) {
+    if (isConfirm !== false) {
       if (onConfirm) onConfirm(isConfirm);
     } else {
       if (onCancel) onCancel(); // eslint-disable-line no-lonely-if


### PR DESCRIPTION
I was running into a issue when using input inside sweetalert and user confirms the dialog without typing anything. This always triggers onCancel instead of onConfirm which at least in my mind would make more sense.

This change allows empty values ('') to flow through onConfirm callback. It seems that sweetalert is just passing false as first value for cancel event so explicitly checking for that.
