### PR TITLE
Removes prototype reference which raises warnings in react 15.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,12 +64,12 @@
   "dependencies": {
     "lodash.pick": "^4.4.0",
     "mousetrap": "^1.6.0",
+    "prop-types": "^15.0.0",
     "sweetalert": "^1.1.3",
     "warning": "^3.0.0"
   },
   "peerDependencies": {
-    "react": "^0.14.0 || ^15.0.0-0",
-    "prop-types": "^15.0.0"
+    "react": "^0.14.0 || ^15.0.0-0"
   },
   "jest": {
     "verbose": true,

--- a/package.json
+++ b/package.json
@@ -68,7 +68,8 @@
     "warning": "^3.0.0"
   },
   "peerDependencies": {
-    "react": "^0.14.0 || ^15.0.0-0"
+    "react": "^0.14.0 || ^15.0.0-0",
+    "prop-types": "^15.0.0"
   },
   "jest": {
     "verbose": true,

--- a/src/SweetAlert.js
+++ b/src/SweetAlert.js
@@ -1,4 +1,5 @@
-import { Component, PropTypes } from 'react';
+import { Component } from 'react';
+import PropTypes from 'prop-types';
 import swal from 'sweetalert';
 import pick from 'lodash.pick';
 import mousetrap from 'mousetrap';


### PR DESCRIPTION
Referencing proptypes from the main react package in the newest version raises
`Warning: Accessing PropTypes via the main React package is deprecated. Use the prop-types package from npm instead.`
Should be fixed by this pr